### PR TITLE
Fixing rabbitmq tls option error

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -100,6 +100,7 @@ rabbitmq:
     #username: guest
     #password: guest
     #erlangCookie: 1234thisisasupersecretoflength32
+    tls: false
 
   ingress:
     enabled: false


### PR DESCRIPTION
Helm chart installation was complaining about missing required value not provided in values.yaml file :

Error: INSTALLATION FAILED: template: pecan/charts/rabbitmq/templates/svc.yaml:48:18: executing "pecan/charts/rabbitmq/templates/svc.yaml" at <.Values.rabbitmq.tls.enabled>: nil pointer evaluating interface {}.tls
helm.go:84: [debug] template: pecan/charts/rabbitmq/templates/svc.yaml:48:18: executing "pecan/charts/rabbitmq/templates/svc.yaml" at <.Values.rabbitmq.tls.enabled>: nil pointer evaluating interface {}.tls
INSTALLATION FAILED
main.newInstallCmd.func2
	helm.sh/helm/v3/cmd/helm/install.go:127
github.com/spf13/cobra.(*Command).execute
	github.com/spf13/cobra@v1.4.0/command.go:856
github.com/spf13/cobra.(*Command).ExecuteC
	github.com/spf13/cobra@v1.4.0/command.go:974
github.com/spf13/cobra.(*Command).Execute
	github.com/spf13/cobra@v1.4.0/command.go:902
main.main
	helm.sh/helm/v3/cmd/helm/helm.go:83
runtime.main
	runtime/proc.go:255
runtime.goexit
	runtime/asm_amd64.s:1581