### PR TITLE
fixing model deployment error

### DIFF
--- a/templates/models/deployment.yaml
+++ b/templates/models/deployment.yaml
@@ -10,7 +10,7 @@ kind: Deployment
 metadata:
   name: {{ $fullname }}-model-{{ $key }}
   labels:
-    {{ $labels | indent 4 }}
+{{ $labels | indent 4 }}
 spec:
   replicas: {{ .replicaCount }}
   selector:


### PR DESCRIPTION
Getting error while deploying helm chart - 
Error: INSTALLATION FAILED: YAML parse error on pecan/templates/models/deployment.yaml: error converting YAML to JSON: yaml: line 6: did not find expected key
helm.go:84: [debug] error converting YAML to JSON: yaml: line 6: did not find expected key
YAML parse error on pecan/templates/models/deployment.yaml